### PR TITLE
Update upstream to 0.58

### DIFF
--- a/signal/Dockerfile
+++ b/signal/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=bbernhard/signal-cli-rest-api:0.56
+ARG BUILD_FROM=bbernhard/signal-cli-rest-api:0.58
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/signal/README.md
+++ b/signal/README.md
@@ -20,7 +20,5 @@ https://www.home-assistant.io/integrations/signal_messenger/
 
 If you want to use i.e. REST to receive messages in HA, you can find more details [here](https://bbernhard.github.io/signal-cli-rest-api/)
 
-To add a desktop application see this (not tested by me): https://github.com/haberda/signal-addon/issues/12
-
 All credit to [@bbernhard](https://github.com/bbernhard), all I did was take his [work](https://github.com/bbernhard/signal-cli-rest-api) and make an add-on.
 

--- a/signal/build.json
+++ b/signal/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "bbernhard/signal-cli-rest-api:0.56",
-    "amd64": "bbernhard/signal-cli-rest-api:0.56",
-    "armv7": "bbernhard/signal-cli-rest-api:0.56"
+    "aarch64": "bbernhard/signal-cli-rest-api:0.58",
+    "amd64": "bbernhard/signal-cli-rest-api:0.58",
+    "armv7": "bbernhard/signal-cli-rest-api:0.58"
   }
 }


### PR DESCRIPTION
Update to latest signal-cli-rest-api.

(0.58)[https://github.com/bbernhard/signal-cli-rest-api/releases/tag/0.58] contains a new endpoint to link a new device through the API, rather than requireing to do it via cli, as suggested in #12.

fix #12