### PR TITLE
Update build.json

### DIFF
--- a/signal/build.json
+++ b/signal/build.json
@@ -1,7 +1,7 @@
 {
   "build_from": {
-    "aarch64": "bbernhard/signal-cli-rest-api:0.62",
-    "amd64": "bbernhard/signal-cli-rest-api:0.62",
-    "armv7": "bbernhard/signal-cli-rest-api:0.62"
+    "aarch64": "bbernhard/signal-cli-rest-api:0.112-dev",
+    "amd64": "bbernhard/signal-cli-rest-api:0.112-dev",
+    "armv7": "bbernhard/signal-cli-rest-api:0.112-dev"
   }
 }


### PR DESCRIPTION
Due to an older UserAgent in version 0.62, signal servers are rejecting client connections. (See https://github.com/bbernhard/signal-cli-rest-api/issues/286, https://github.com/bbernhard/signal-cli-rest-api/issues/287). This dev build resolves the issue while the maintainer of signal-cli-rest-api works to update the repo to the latest version of signal-cli.