### PR TITLE
Update URL in config.yaml to link to main GitHub repo page

### DIFF
--- a/signal/config.yaml
+++ b/signal/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Signal Messenger
-url: https://github.com/haberda/signal-addon/tree/master/
+url: https://github.com/haberda/signal-addon
 version: dev
 slug: signal_messenger
 arch:


### PR DESCRIPTION
Master branch doesn't exist anymore. GitHub shows the default branch when visiting the main repo page.