### PR TITLE
add option to set default signal text mode

### DIFF
--- a/signal/DOCS.md
+++ b/signal/DOCS.md
@@ -35,6 +35,13 @@ Valid options:
 - `off`: Disable Auto receive
 - `on`: Enable Auto receive (default)
 
+### Default Signal Text Mode
+
+Sets the default text mode for outbound messages. Comes into play, if `text_mode` is not set as part of the request payload.
+
+- `normal`: no formatting options
+- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~` 
+
 ### SIGNAL-CLI Command Timeout
 
 This option sets the time in seconds to wait before timing out the signal cli command. This option does not apply to json-rpc mode and will be ignored in that mode.(default: 60s)

--- a/signal/DOCS.md
+++ b/signal/DOCS.md
@@ -40,7 +40,7 @@ Valid options:
 Sets the default text mode for outbound messages. Only comes into play, if `text_mode` is not set for an individual message as part of the request payload.
 
 - `normal`: no formatting options
-- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~` 
+- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~`
 
 ### SIGNAL-CLI Command Timeout
 

--- a/signal/DOCS.md
+++ b/signal/DOCS.md
@@ -37,10 +37,10 @@ Valid options:
 
 ### Default Signal Text Mode
 
-Sets the default text mode for outbound messages. Comes into play, if `text_mode` is not set as part of the request payload.
+Sets the default text mode for outbound messages. Only comes into play, if `text_mode` is not set for an individual message as part of the request payload.
 
 - `normal`: no formatting options
-- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~`
+- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~` 
 
 ### SIGNAL-CLI Command Timeout
 

--- a/signal/DOCS.md
+++ b/signal/DOCS.md
@@ -40,7 +40,7 @@ Valid options:
 Sets the default text mode for outbound messages. Comes into play, if `text_mode` is not set as part of the request payload.
 
 - `normal`: no formatting options
-- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~` 
+- `styled`: renders `*italic*`, `**bold**`, `~strikethrough~`
 
 ### SIGNAL-CLI Command Timeout
 

--- a/signal/build.yaml
+++ b/signal/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: bbernhard/signal-cli-rest-api:0.100
   amd64: bbernhard/signal-cli-rest-api:0.100
-  armv7: bbernhard/signal-cli-rest-api:0.100

--- a/signal/config.yaml
+++ b/signal/config.yaml
@@ -14,15 +14,17 @@ ports:
 ports_description:
   8080/tcp: Rest-api port
 options:
-  mode: list(normal|native|json-rpc)
+  mode: normal
   AUTO_RECEIVE: true
   SIGNAL_CLI_CMD_TIMEOUT: 60
+  DEFAULT_SIGNAL_TEXT_MODE: normal
 map:
   - addon_config:rw
 schema:
   mode: list(normal|native|json-rpc)
   AUTO_RECEIVE: bool
   SIGNAL_CLI_CMD_TIMEOUT: int
+  DEFAULT_SIGNAL_TEXT_MODE: list(normal|styled)
 environment:
   SIGNAL_CLI_CONFIG_DIR: /config
 image: ghcr.io/haberda/signal/{arch}

--- a/signal/options.sh
+++ b/signal/options.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# move config from old to new locations if necessary
-#if [ -d /data/data ]
-#then
-#	mv -f /data/* /config
-#    mv -f /config/options.json /data
-#	rm -rf /data/data
-#fi
-
 CONFIG_PATH=/data/options.json
 
 export MODE_tmp=$(jq --raw-output '.mode // empty' "$CONFIG_PATH")
@@ -19,13 +11,6 @@ export SIGNAL_CLI_CMD_TIMEOUT_tmp=$(jq --raw-output '.SIGNAL_CLI_CMD_TIMEOUT // 
 
 export reset_data=$(jq --raw-output '.reset_data // empty' "$CONFIG_PATH")
 
-#if [ $reset_data ]
-#then
-#	rm -r /data/*
-#	echo "Data deleted. Please set reset_data to off and restart the addon."
-#	exit
-#fi
-#
 export MODE=$(jq --raw-output '.mode // empty' "$CONFIG_PATH")
 
 export DEFAULT_SIGNAL_TEXT_MODE=$(jq --raw-output '.DEFAULT_SIGNAL_TEXT_MODE // "normal"' $CONFIG_PATH)

--- a/signal/options.sh
+++ b/signal/options.sh
@@ -11,13 +11,13 @@ set -e
 
 CONFIG_PATH=/data/options.json
 
-export MODE_tmp=$(jq --raw-output '.mode // empty' $CONFIG_PATH)
+export MODE_tmp=$(jq --raw-output '.mode // empty' "$CONFIG_PATH")
 
-export AUTO_RECEIVE_SCHEDULE_bool=$(jq --raw-output '.AUTO_RECEIVE // empty' $CONFIG_PATH)
+export AUTO_RECEIVE_SCHEDULE_bool=$(jq --raw-output '.AUTO_RECEIVE // empty' "$CONFIG_PATH")
 
-export SIGNAL_CLI_CMD_TIMEOUT_tmp=$(jq --raw-output '.SIGNAL_CLI_CMD_TIMEOUT // empty' $CONFIG_PATH)
+export SIGNAL_CLI_CMD_TIMEOUT_tmp=$(jq --raw-output '.SIGNAL_CLI_CMD_TIMEOUT // empty' "$CONFIG_PATH")
 
-export reset_data=$(jq --raw-output '.reset_data // empty' $CONFIG_PATH)
+export reset_data=$(jq --raw-output '.reset_data // empty' "$CONFIG_PATH")
 
 #if [ $reset_data ]
 #then
@@ -26,20 +26,20 @@ export reset_data=$(jq --raw-output '.reset_data // empty' $CONFIG_PATH)
 #	exit
 #fi
 #
-export MODE=$(jq --raw-output '.mode // empty' $CONFIG_PATH)
+export MODE=$(jq --raw-output '.mode // empty' "$CONFIG_PATH")
 
 export DEFAULT_SIGNAL_TEXT_MODE=$(jq --raw-output '.DEFAULT_SIGNAL_TEXT_MODE // "normal"' $CONFIG_PATH)
 
 if [ "${MODE_tmp}" != "json-rpc" ]; then
 
-	if [ $AUTO_RECEIVE_SCHEDULE_bool ]
+	if [ "${AUTO_RECEIVE_SCHEDULE_bool}" = "true" ]
 	then
 	  export AUTO_RECEIVE_SCHEDULE='0 22 * * *'
 	fi
 
-	if [ $SIGNAL_CLI_CMD_TIMEOUT_tmp -ne 0 ]
+	if [ -n "${SIGNAL_CLI_CMD_TIMEOUT_tmp}" ] && [ "${SIGNAL_CLI_CMD_TIMEOUT_tmp}" -ne 0 ]
 	then
-	  export SIGNAL_CLI_CMD_TIMEOUT=$(jq --raw-output '.SIGNAL_CLI_CMD_TIMEOUT // empty' $CONFIG_PATH)
+	  export SIGNAL_CLI_CMD_TIMEOUT="${SIGNAL_CLI_CMD_TIMEOUT_tmp}"
 	fi
 
 fi

--- a/signal/options.sh
+++ b/signal/options.sh
@@ -2,7 +2,7 @@
 set -e
 
 # move config from old to new locations if necessary
-#if [ -d /data/data ] 
+#if [ -d /data/data ]
 #then
 #	mv -f /data/* /config
 #    mv -f /config/options.json /data
@@ -27,6 +27,8 @@ export reset_data=$(jq --raw-output '.reset_data // empty' $CONFIG_PATH)
 #fi
 #
 export MODE=$(jq --raw-output '.mode // empty' $CONFIG_PATH)
+
+export DEFAULT_SIGNAL_TEXT_MODE=$(jq --raw-output '.DEFAULT_SIGNAL_TEXT_MODE // "normal"' $CONFIG_PATH)
 
 if [ "${MODE_tmp}" != "json-rpc" ]; then
 


### PR DESCRIPTION
Problem statement
I am hosting the Rest API and Signal CLI as a Home Assistant add on.
In addition to Home Assistant, I have other services which use this Rest API. 
Some of them (namely the n8n Signal Node) do not support setting the text mode for outgoing messages.
For these, I have no way, to use styled messages

Proposed Solution - as implmeneted in this PR
Add an option to set the DEFAULT_SIGNAL_TEXT_MODE for the Signal CLI.